### PR TITLE
int overflow for document expiration >30days

### DIFF
--- a/driver/src/main/scala/org/reactivecouchbase/CouchbaseExpirationManagement.scala
+++ b/driver/src/main/scala/org/reactivecouchbase/CouchbaseExpirationManagement.scala
@@ -16,6 +16,6 @@ object CouchbaseExpiration {
 
   implicit def from_CouchbaseExpirationTiming_to_int(a: CouchbaseExpirationTiming): Int = a match {
     case i: CouchbaseExpirationTiming_byInt => i.value
-    case d: CouchbaseExpirationTiming_byDuration => if (d.value < 30.days) d.value.toSeconds.toInt else { (System.currentTimeMillis() + d.value.toMillis).toInt / 1000 }
+    case d: CouchbaseExpirationTiming_byDuration => if (d.value <= 30.days) d.value.toSeconds.toInt else ((System.currentTimeMillis() + d.value.toMillis) / 1000).toInt
   }
 }

--- a/driver/src/test/scala/CouchbaseExpirationSpec.scala
+++ b/driver/src/test/scala/CouchbaseExpirationSpec.scala
@@ -1,0 +1,22 @@
+import org.specs2.mutable.Specification
+import org.specs2.time.NoTimeConversions
+import scala.compat.Platform
+import scala.concurrent.duration._
+import org.reactivecouchbase.CouchbaseExpiration._
+
+class CouchbaseExpirationSpec extends Specification with NoTimeConversions {
+  "CouchbaseExpiration" should {
+    "use TTL in seconds for expiration <=30 days" in {
+      val expiration = 30.days
+
+      ((expiration: CouchbaseExpirationTiming): Int) === expiration.toSeconds
+
+    }
+    "use unix epoch for expiration >30 days" in {
+      val expiration = 30.days + 1.second
+
+      val expectedUnixEpoch = ((Platform.currentTime + expiration.toMillis) / 1000).toInt
+      ((expiration: CouchbaseExpirationTiming): Int) must be ~ (expectedUnixEpoch +/- 3)
+    }
+  }
+}


### PR DESCRIPTION
Fixed an Integer overflow as the conversion from Millis to Seconds was done AFTER the Long->Int conversion
