### PR TITLE
updated couchbase version from 1.4.2 to 1.4.4

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -44,7 +44,7 @@ object ApplicationBuild extends Build {
     .settings(baseSettings: _*)
     .settings(
       resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
-      libraryDependencies += "com.couchbase.client" % "couchbase-client" % "1.4.2",
+      libraryDependencies += "com.couchbase.client" % "couchbase-client" % "1.4.4",
       libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.3.3" cross CrossVersion.binary,
       libraryDependencies += "com.typesafe.play" %% "play-iteratees" % "2.3.0" cross CrossVersion.binary,
       libraryDependencies += "com.typesafe.play" %% "play-json" % "2.3.0" cross CrossVersion.binary,


### PR DESCRIPTION
Passed 100 of 100 test:

 [info] Passed: Total 100, Failed 0, Errors 0, Passed 100
 [success] Total time: 28 s, completed Oct 16, 2014 3:24:56 PM 

Release notes for 1.4.3 and 1.4.4 can be found here: http://docs.couchbase.com/couchbase-sdk-java-1.4/#release-notes-for-couchbase-client-library-java-144-ga-5-august-2014

This should help with people complaining of reconnect issues and with people being unable to read from replica. Along with other misc fixes.  Since it is a minor updates there are no breaking changes (unlike version 2.0)
