### PR TITLE
Fix AsyncHttpClient thread hang on hostname verification failure

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -49,7 +49,7 @@ object ApplicationBuild extends Build {
       libraryDependencies += "com.typesafe.play" %% "play-iteratees" % "2.3.0" cross CrossVersion.binary,
       libraryDependencies += "com.typesafe.play" %% "play-json" % "2.3.0" cross CrossVersion.binary,
       libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.1.1",
-      libraryDependencies += "com.ning" % "async-http-client" % "1.8.8",
+      libraryDependencies += "com.ning" % "async-http-client" % "1.8.14",
       libraryDependencies += "com.typesafe" % "config" % "1.2.1",
       libraryDependencies += "org.specs2" %% "specs2" % "2.3.12" % "test" cross CrossVersion.binary,
       organization := "org.reactivecouchbase",


### PR DESCRIPTION
AsyncHttpClient hangs the thread if hostname verification fails in 1.8.8.  Upgrading to 1.8.14 will fix the issue.

See https://github.com/playframework/playframework/issues/3540 and https://github.com/AsyncHttpClient/async-http-client/issues/555.
