### PR TITLE
updated couchbase driver to 1.4.6 to fix reconnect bugs

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -44,7 +44,7 @@ object ApplicationBuild extends Build {
     .settings(baseSettings: _*)
     .settings(
       resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
-      libraryDependencies += "com.couchbase.client" % "couchbase-client" % "1.4.5",
+      libraryDependencies += "com.couchbase.client" % "couchbase-client" % "1.4.6",
       libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.3.6" cross CrossVersion.binary,
       libraryDependencies += "com.typesafe.play" %% "play-iteratees" % "2.3.5" cross CrossVersion.binary,
       libraryDependencies += "com.typesafe.play" %% "play-json" % "2.3.5" cross CrossVersion.binary,


### PR DESCRIPTION
Updating couchbase client to 1.4.6 to fix reconnect issues.

Total bug improvements found here:
```


    SPY-179: A wrong reconnect delay ceiling was applied, leading to very long reconnect delays when the node in question was down for a longer time. The fix applied now correctly translates the “max reconnect time” and applies the proper ceiling. This allows the client to recover much quicker when a node has been down for a longer time.

    JCBC-620: The newly introduced diagnostics feature optionally uses some private packages that might not be available in all environments. This prevented startup in unsupported environments because the class loader would complain immediately. Proper guards are now in place to conditionally use the feature when available and gracefully degrade if not.

    SPY-178: When memcached buckets are used and the KetamaNodeLocator method is accessed directly, the getReadonlyCopy method was subject to iterator failures when used in combination with the -XX:+AggressiveOpts JVM flag.
```

Link found [here](http://docs.couchbase.com/couchbase-sdk-java-1.4/#release-notes)