### PR TITLE
Analyzing status code for ERR_NOT_FOUND in addition to status message

### DIFF
--- a/driver/src/main/scala/org/reactivecouchbase/client/Queries.scala
+++ b/driver/src/main/scala/org/reactivecouchbase/client/Queries.scala
@@ -174,13 +174,13 @@ trait Queries {
     } else {
       QueryEnumerator(() => waitForHttp[ViewResponse]( bucket.couchbaseClient.asyncQuery(view, query), bucket, ec ).map { results =>
         Enumerator.enumerate(results.iterator()) &> Enumeratee.map[ViewRow] {
-          case r: ViewRowWithDocs if query.willIncludeDocs() => RawRow(Some(r.getDocument.asInstanceOf[String]), Some(r.getId), r.getKey, r.getValue)
-          case r: ViewRowWithDocs if !query.willIncludeDocs() => RawRow(None, Some(r.getId), r.getKey, r.getValue)
-          case r: ViewRowNoDocs => RawRow(None, Some(r.getId), r.getKey, r.getValue)
+          case r: ViewRowWithDocs if query.willIncludeDocs() => RawRow(Option(r.getDocument.asInstanceOf[String]), Option(r.getId), r.getKey, r.getValue)
+          case r: ViewRowWithDocs if !query.willIncludeDocs() => RawRow(None, Option(r.getId), r.getKey, r.getValue)
+          case r: ViewRowNoDocs => RawRow(None, Option(r.getId), r.getKey, r.getValue)
           case r: ViewRowReduced => RawRow(None, None, r.getKey, r.getValue)
-          case r: SpatialViewRowNoDocs => RawRow(None, Some(r.getId), r.getKey, r.getValue)
-          case r: SpatialViewRowWithDocs if query.willIncludeDocs() => RawRow(Some(r.getDocument.asInstanceOf[String]), Some(r.getId), r.getKey, r.getValue)
-          case r: SpatialViewRowWithDocs if !query.willIncludeDocs() => RawRow(None, Some(r.getId), r.getKey, r.getValue)
+          case r: SpatialViewRowNoDocs => RawRow(None, Option(r.getId), r.getKey, r.getValue)
+          case r: SpatialViewRowWithDocs if query.willIncludeDocs() => RawRow(Option(r.getDocument.asInstanceOf[String]), Option(r.getId), r.getKey, r.getValue)
+          case r: SpatialViewRowWithDocs if !query.willIncludeDocs() => RawRow(None, Option(r.getId), r.getKey, r.getValue)
         }
       })
     }


### PR DESCRIPTION
Not only should the status message be analyzed, but also the status code. For instance, CouchbaseMock does not contain proper text message but it has the proper status code enum.